### PR TITLE
Edit incorrect statement about "FixedUpdate"

### DIFF
--- a/docs/basic/harmony_guide.md
+++ b/docs/basic/harmony_guide.md
@@ -34,7 +34,7 @@ of the class you are patching).
 An example patch is below. 
 In particular, we call which class we want to detect, for instance, we will use the `PlayerControl` class.  
 After that, we would like to define what method we want to detect in that class. In this scenario, we will 
-use the `FixedUpdate` method which runs every frame in the game.
+use the `FixedUpdate` method which runs every time the engine updates physics.
 
 In order for us to patch this class and method, we can use the following line:
 ```csharp


### PR DESCRIPTION
Hi! 

This PR fixes an error in the documentation that states that "FixedUpdate is ran every frame".

This is in fact not true. FixedUpdate is ran every physics update. It is frame rate independent and is only called a set number of times per second, hence the name FixedUpdate.

Unity Documentation for fixed update: https://docs.unity3d.com/ScriptReference/MonoBehaviour.FixedUpdate.html